### PR TITLE
[Feature] 퀄업 요소 구현

### DIFF
--- a/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
+++ b/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
@@ -1254,6 +1254,63 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 4da415d70811ed54e812bd16bb0e8247, type: 3}
   m_PrefabInstance: {fileID: 1974880004}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &140045278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 327
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 289
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3367199830763010627, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4342121712904260192, guid: c0d935473177bd24dada70a46aa53535, type: 3}
+      propertyPath: m_Name
+      value: PixelateAndGreyScaleManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c0d935473177bd24dada70a46aa53535, type: 3}
 --- !u!1001 &147668901
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4204,6 +4261,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d479495a57334f409b5cdbacdd574e0, type: 3}
+--- !u!1001 &767154165
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4348975464994014536, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_Name
+      value: LoadingManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 327
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 289
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5969672231674878352, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 251dde53d7c8e7d4184ae4e502900cf2, type: 3}
 --- !u!1 &774558664 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7516567603537690636, guid: b931c348be7c7c24b96ee67ee23a45e1, type: 3}
@@ -11096,3 +11210,5 @@ SceneRoots:
   - {fileID: 661361301005550368}
   - {fileID: 8668076816034612162}
   - {fileID: 3329102163333965222}
+  - {fileID: 140045278}
+  - {fileID: 767154165}

--- a/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
+++ b/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
@@ -7017,24 +7017,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94ef42f644130b046b34da3da814dfe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1427024311 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8022095829948060203, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
-  m_PrefabInstance: {fileID: 4066385526230859219}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1427024312
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1427024311}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fadeDuration: 1.5
 --- !u!1001 &1450293988
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7351,11 +7333,6 @@ MonoBehaviour:
 Transform:
   m_CorrespondingSourceObject: {fileID: 9078641536990461099, guid: ad5acee826c5e3e4193ee726e3d27c0f, type: 3}
   m_PrefabInstance: {fileID: 533316263}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1594936279 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3818844191061978318, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
-  m_PrefabInstance: {fileID: 5071172295253506033}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1606620417
 PrefabInstance:
@@ -10889,10 +10866,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 8022095829948060203, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1427024312}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
 --- !u!1001 &5071172295253506033
 PrefabInstance:
@@ -10946,10 +10920,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5547200359903120273, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
-      propertyPath: 'm_Materials.Array.data[1]'
-      value: 
-      objectReference: {fileID: 2100000, guid: 05791b371dd88704dba53012b9ab30fd, type: 2}
     - target: {fileID: 7770965207224362309, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
       propertyPath: inventoryUI
       value: 
@@ -10957,29 +10927,13 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3818844191061978318, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7733775997575694005}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
 --- !u!4 &7733775997575694004 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4690475670055653801, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
   m_PrefabInstance: {fileID: 5071172295253506033}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &7733775997575694005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1594936279}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fadeDuration: 1.5
 --- !u!1001 &7984537958656356446
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
+++ b/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
@@ -378,6 +378,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: RabbitsHouse
       objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 3938860565958572097, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
@@ -1382,6 +1386,10 @@ PrefabInstance:
     - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
       propertyPath: m_Name
       value: OldLibrary
+      objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
@@ -3695,6 +3703,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Yard
       objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 3938860565958572097, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
@@ -3943,6 +3955,10 @@ PrefabInstance:
     - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
       propertyPath: m_Name
       value: DarkTunnel
+      objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
@@ -4921,6 +4937,10 @@ PrefabInstance:
     - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
       propertyPath: m_Name
       value: BigApple
+      objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
@@ -7082,6 +7102,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Forest
       objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 3938860565958572097, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
@@ -8211,6 +8235,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GoldTunnel
       objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 3938860565958572097, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
@@ -9305,6 +9333,10 @@ PrefabInstance:
     - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
       propertyPath: m_Name
       value: BehindTree
+      objectReference: {fileID: 0}
+    - target: {fileID: 8680141207348165856, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
+++ b/After Christmas/Assets/01. Scenes/GHB/DemoTest-UIMakeScene.unity
@@ -1620,6 +1620,18 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: f9a94780aa94b7c4985400ab0bedcdbb, type: 2}
     - target: {fileID: 6893754215918668224, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
       propertyPath: cutsceneEventList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6893754215918668224, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: cutsceneEventList.Array.data[0].dialogueData
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6893754215918668224, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: cutsceneEventList.Array.data[0].cinematicTimeline
+      value: 
+      objectReference: {fileID: 1645884952}
+    - target: {fileID: 6893754215918668224, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
+      propertyPath: cutsceneEventList.Array.data[0].hasDialogueContent
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7267863606461305299, guid: 220f8aaf7458be24e98749ddae62bdaa, type: 3}
@@ -6871,6 +6883,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94ef42f644130b046b34da3da814dfe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1427024311 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8022095829948060203, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
+  m_PrefabInstance: {fileID: 4066385526230859219}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1427024312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427024311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeDuration: 1.5
 --- !u!1001 &1450293988
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7184,6 +7214,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9078641536990461099, guid: ad5acee826c5e3e4193ee726e3d27c0f, type: 3}
   m_PrefabInstance: {fileID: 533316263}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1594936279 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818844191061978318, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
+  m_PrefabInstance: {fileID: 5071172295253506033}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1606620417
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7350,6 +7385,8 @@ GameObject:
   - component: {fileID: 1645884950}
   - component: {fileID: 1645884949}
   - component: {fileID: 1645884948}
+  - component: {fileID: 1645884952}
+  - component: {fileID: 1645884951}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -7446,6 +7483,47 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1645884946}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!95 &1645884951
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645884946}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!320 &1645884952
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645884946}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 24c0fb7f67c6a544fb80fbf66e5c15de, type: 2}
+  m_InitialState: 1
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: -3930594027859149275, guid: 24c0fb7f67c6a544fb80fbf66e5c15de, type: 2}
+    value: {fileID: 1645884951}
+  m_ExposedReferences:
+    m_References: []
 --- !u!1001 &1659667372
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10665,7 +10743,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8022095829948060203, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1427024312}
   m_SourcePrefab: {fileID: 100100000, guid: 55a9042b6d08585429d52d63db44a202, type: 3}
 --- !u!1001 &5071172295253506033
 PrefabInstance:
@@ -10719,6 +10800,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5547200359903120273, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 05791b371dd88704dba53012b9ab30fd, type: 2}
     - target: {fileID: 7770965207224362309, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
       propertyPath: inventoryUI
       value: 
@@ -10726,13 +10811,29 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3818844191061978318, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7733775997575694005}
   m_SourcePrefab: {fileID: 100100000, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
 --- !u!4 &7733775997575694004 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4690475670055653801, guid: e59c27b2c25d61143b8145d138c3ffa8, type: 3}
   m_PrefabInstance: {fileID: 5071172295253506033}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7733775997575694005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1594936279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeDuration: 1.5
 --- !u!1001 &7984537958656356446
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/After Christmas/Assets/02. Scripts/Cinemachine/CinematicController.cs
+++ b/After Christmas/Assets/02. Scripts/Cinemachine/CinematicController.cs
@@ -8,6 +8,9 @@ using System;
 public class CinematicController : MonoBehaviour
 {
 
+    public static Action OnStart;
+    public static Action OnEnd;
+
     public List<CutsceneEvent> cutsceneEventList;
 
     // 컷신 실행 상태 관리를 위한 코루틴
@@ -34,6 +37,7 @@ public class CinematicController : MonoBehaviour
     public void StartCutscene(Action onCutsceneEnd = null)
     {
         Debug.Log("시네마틱 시작됨");
+        OnStart?.Invoke();
 
         // 1. 시네마틱 시작 시 플레이어 상태 CINEMATIC으로 전환
         PlayerStateManager.Instance?.SetState(PlayerState.Cinematic);
@@ -45,7 +49,7 @@ public class CinematicController : MonoBehaviour
             {
                 // 2. 시네마틱 종료 시 플레이어 상태 PLAY로 전환
                 PlayerStateManager.Instance?.SetState(PlayerState.Play);
-
+                OnEnd?.Invoke();
                 // 기존 외부 콜백이 있으면 실행
                 onCutsceneEnd?.Invoke();
             }));

--- a/After Christmas/Assets/02. Scripts/InteractObj/Item.cs
+++ b/After Christmas/Assets/02. Scripts/InteractObj/Item.cs
@@ -213,15 +213,20 @@ public class Item : MonoBehaviour, IInteractable, IGlowable
     private IEnumerator TeleportByItemRoutine(GameObject player, Item target)
     {
         PlayerStateManager.Instance.SetState(PlayerState.Fading);
+        Map currentMap = GetComponentInParent<Map>(true);
+        Map targetMap = target.GetComponentInParent<Map>(true);
         // 페이드 아웃
         bool isFadeOutComplete = false;
         FadeManager.Instance.FadeOut(() => { isFadeOutComplete = true; });
 
         // 페이드 아웃 끝날 때까지 대기
         yield return new WaitUntil(() => isFadeOutComplete);
-
+        
         // 0.5초 딜레이
         yield return new WaitForSeconds(0.5f);
+
+        // 이동할 맵 활성화
+        targetMap.gameObject.SetActive(true);
 
         // 위치 이동
         player.transform.SetPositionAndRotation(
@@ -235,8 +240,10 @@ public class Item : MonoBehaviour, IInteractable, IGlowable
                 target.cameraSpawnPoint.rotation
             );
 
-        Map map = target.GetComponentInParent<Map>();
-        MapInfoManager.Instance.currentMap = map.mapName;
+        // 이동 후 기존에 위치했던 맵 비활성화
+        currentMap.gameObject.SetActive(false);
+        
+        MapInfoManager.Instance.currentMap = targetMap.mapName;
 
         TeleportEventManager.NotifyTeleport();
 

--- a/After Christmas/Assets/02. Scripts/Manager/MinimapManager.cs
+++ b/After Christmas/Assets/02. Scripts/Manager/MinimapManager.cs
@@ -203,7 +203,7 @@ public class MinimapManager : MonoBehaviour
     }
 
 
-    private void MoveToOriginal(Vector3 targetCameraPosition, Vector3 targetPlayerPosition, bool isMapMove)
+    private void MoveToOriginal(Vector3 targetCameraPosition, Vector3 targetPlayerPosition, bool isMapMove, Map newMap = null)
     {
         isTweening = true;
         hoveredMap = null;
@@ -238,7 +238,30 @@ public class MinimapManager : MonoBehaviour
                 EnableAllMapObjects();
                 PlayerStateManager.Instance.SetState(PlayerState.Play);
                 CloseAllPostIts();
+                if(newMap != null)
+                {
+                    DisableOtherMap();
+                }
             });
+    }
+
+    private void DisableOtherMap()
+    {
+        int sceneIndex = MapInfoManager.Instance.GetSceneIndex(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene().name
+        );
+        if (sceneIndex < 0) return;
+
+        var mapIDs = MapInfoManager.Instance.GetAllMapIDs(sceneIndex);
+
+        foreach (var mapID in mapIDs)
+        {
+            Map mapObj = MapInfoManager.Instance.GetMapObject(mapID);
+            if (mapID != MapInfoManager.Instance.currentMap)
+            {
+                mapObj.gameObject.SetActive(false);
+            }
+        }
     }
 
 
@@ -388,7 +411,7 @@ public class MinimapManager : MonoBehaviour
             {
                 // Map 클릭 시, 다른 맵이라면 해당 Map으로 텔레포트 처리
                 MapInfoManager.Instance.currentMap = map.mapName;
-                MoveToOriginal(map.cameraSpawnPoint.position, map.playerSpawnPoint.position, true);
+                MoveToOriginal(map.cameraSpawnPoint.position, map.playerSpawnPoint.position, true, map);
             }
             else
             {

--- a/After Christmas/Assets/02. Scripts/Manager/StageManager.cs
+++ b/After Christmas/Assets/02. Scripts/Manager/StageManager.cs
@@ -5,9 +5,14 @@ using UnityEngine.SceneManagement;
 
 public class StageManager : MonoBehaviour
 {
+    [Header("Clear Settings")]
+    [SerializeField] private int requiredInteractionCount;
+    [SerializeField] private string nextSceneName; // 다음으로 이동할 씬 이름(기획상 현실세계)
+    public TransitionSettings clearTransitionSettings; // 스테이지 전용 전환 설정, 인스펙터에서 설정 가능
+
     // 스테이지 클리어 시 진행할 대화
     private DialogueTrigger dialogueTrigger;
-    [SerializeField] private int requiredInteractionCount;
+    
     private int currentInteractionCount = 0;
 
     private void Awake()
@@ -64,6 +69,16 @@ public class StageManager : MonoBehaviour
 
     private void StageClear()
     {
-        // 진짜 스테이지 클리어 로직 넣기
+        // 타겟 씬으로 이동
+        TempLoadingManager.Instance.TransitionTo(nextSceneName, clearTransitionSettings);
+    }
+
+    private void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.Tab))
+        {
+            Debug.Log("클리어 디버그 작동");
+            IncreaseCount();
+        }
     }
 }

--- a/After Christmas/Assets/02. Scripts/Map/Map.cs
+++ b/After Christmas/Assets/02. Scripts/Map/Map.cs
@@ -40,6 +40,10 @@ public class Map : MonoBehaviour
     {
         MapInfoManager.Instance.RecordMap(this);
         InitializeChildItems();
+        if (!isStartMap)
+        {
+            gameObject.SetActive(false);
+        }
     }
 
     private void InitializeChildItems()

--- a/After Christmas/Assets/02. Scripts/Player/PlayerAlphaFader.cs
+++ b/After Christmas/Assets/02. Scripts/Player/PlayerAlphaFader.cs
@@ -1,0 +1,143 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class PlayerAlphaFader : MonoBehaviour
+{
+    
+    private string transparencyProp = "_Tweak_transparency";
+    private float transparentAlphaValue = -1.0f;
+    private float normalAlphaValue = 0.0f;
+    [SerializeField] private float fadeDuration;
+
+    private List<Renderer> renderers = new List<Renderer>();
+    private MaterialPropertyBlock propBlock;
+    private Coroutine activeFadeRoutine;
+    private int transparencyId;
+    private CapsuleCollider cd;
+    private Rigidbody rb;
+
+    void Awake()
+    {
+        Init();
+    }
+
+    private void OnEnable()
+    {
+        CinematicController.OnStart += SetTransparentInstant;
+        CinematicController.OnEnd += SetOpaqueGradual;
+    }
+
+    private void OnDisable()
+    {
+        CinematicController.OnStart -= SetTransparentInstant;
+        CinematicController.OnEnd -= SetOpaqueGradual;
+    }
+
+    public void CacheRenderers()
+    {
+        renderers.Clear();
+        Renderer[] children = GetComponentsInChildren<Renderer>(true);
+        foreach (var r in children)
+        {
+            renderers.Add(r);
+        }
+    }
+
+    public void SetTransparentInstant()
+    {
+        StopActiveRoutine();
+        ApplyTransparency(transparentAlphaValue);
+        TogglePhysics(false);
+    }
+
+    public void SetOpaqueGradual()
+    {
+        StopActiveRoutine();
+        TogglePhysics(true);
+        activeFadeRoutine = StartCoroutine(FadeRoutine(normalAlphaValue));
+    }
+
+    private void ApplyTransparency(float alpha)
+    {
+        float clampedAlpha = Mathf.Clamp(alpha, -1.0f, 0.0f);
+
+        foreach (var r in renderers)
+        {
+            r.GetPropertyBlock(propBlock);
+            propBlock.SetFloat(transparencyId, clampedAlpha);
+            r.SetPropertyBlock(propBlock);
+        }
+    }
+
+    private IEnumerator FadeRoutine(float targetValue)
+    {
+        float startValue = GetCurrentTransparency();
+        float elapsedTime = 0;
+
+        while (elapsedTime < fadeDuration)
+        {
+            elapsedTime += Time.deltaTime;
+            float lerpValue = Mathf.Lerp(startValue, targetValue, elapsedTime / fadeDuration);
+
+            ApplyTransparency(lerpValue);
+            yield return null;
+        }
+
+        ApplyTransparency(targetValue);
+        activeFadeRoutine = null;
+    }
+
+    private float GetCurrentTransparency()
+    {
+        if (renderers.Count > 0)
+        {
+            renderers[0].GetPropertyBlock(propBlock);
+            return propBlock.GetFloat(transparencyId);
+        }
+        return transparentAlphaValue;
+    }
+
+    private void StopActiveRoutine()
+    {
+        if (activeFadeRoutine != null)
+        {
+            StopCoroutine(activeFadeRoutine);
+            activeFadeRoutine = null;
+        }
+    }
+
+    // 셰이더만 제어할 게 아니라, 시네마틱 감안한다면 물리연산, 콜라이더도 꺼야 함
+    private void TogglePhysics(bool isEnabled)
+    {
+        if (cd != null) 
+        {
+            cd.enabled = isEnabled;
+        }
+        if (rb != null)
+        {
+            // 활성화 상태 - Kinematic 끔
+            // 비활성화(시네마틱) 상태 - Kinematic켜기
+            rb.isKinematic = !isEnabled;
+            if (isEnabled)
+            {
+                rb.linearVelocity = Vector3.zero;
+                rb.angularVelocity = Vector3.zero;
+            }
+        }
+    }
+
+
+
+    private void Init()
+    {
+        transparencyId = Shader.PropertyToID(transparencyProp);
+        propBlock = new MaterialPropertyBlock();
+
+        CacheRenderers();
+
+        SetTransparentInstant();
+        cd = GetComponent<CapsuleCollider>();
+        rb = GetComponent<Rigidbody>();
+    }
+}

--- a/After Christmas/Assets/02. Scripts/Player/PlayerAlphaFader.cs.meta
+++ b/After Christmas/Assets/02. Scripts/Player/PlayerAlphaFader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1953309df466554d83d862c7305562e

--- a/After Christmas/Assets/02. Scripts/Player/PlayerItemHandler.cs
+++ b/After Christmas/Assets/02. Scripts/Player/PlayerItemHandler.cs
@@ -117,9 +117,8 @@ public class PlayerItemHandler : MonoBehaviour
     private void Update()
     {
         // inventoryUI가 null이 아니고, 오브젝트가 파괴되지 않은 경우만 열기
-        if (Input.GetKeyDown(KeyCode.F))
+        if (Input.GetKeyDown(KeyCode.F) && IsInventoryControlEnabled)
         {
-
             if (inventoryUI != null && inventoryUI.gameObject != null)
             {
                 if (inventoryUI.gameObject.activeSelf)
@@ -133,4 +132,7 @@ public class PlayerItemHandler : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.G))
             UnHoldItem();
     }
+
+    private bool IsInventoryControlEnabled =>
+        PlayerStateManager.Instance.currentState is PlayerState.Play or PlayerState.UIOpen;
 }

--- a/After Christmas/Assets/02. Scripts/TempLoadingManager.cs
+++ b/After Christmas/Assets/02. Scripts/TempLoadingManager.cs
@@ -2,18 +2,30 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+[System.Serializable]
+public class TransitionSettings
+{
+    [Header("현재 씬 → 로딩씬 효과 온오프")]
+    public bool useOutEffect = true;  // A -> 로딩
+    [Header("로딩씬 → 타겟 씬 효과 온오프")]
+    public bool useInEffect = true;   // 로딩 -> B
+    [Header("현재 씬 → 로딩씬 픽셀레이트 지속시간")]
+    public float outDuration = 1.0f;
+    [Header("로딩씬 → 타겟 씬 픽셀레이트 지속시간")]
+    public float inDuration = 1.0f;
+}
+
 public class TempLoadingManager : MonoBehaviour
 {
     public static TempLoadingManager Instance { get; private set; }
 
-    [Header("Transition Settings")]
-    public string targetSceneName = "";
     public string loadingSceneName = "LoadingScene";
-    public float transitionTime = 1.0f;
+    
+    // 기본 설정값
+    public TransitionSettings defaultSettings;
 
     private void Awake()
     {
-        // 싱글톤 및 파괴 방지 설정
         if (Instance == null)
         {
             Instance = this;
@@ -25,60 +37,65 @@ public class TempLoadingManager : MonoBehaviour
         }
     }
 
-    public void TransitionTo(string sceneName)
+    // 외부에서 호출할 때 설정을 같이 넘겨줌
+    public void TransitionTo(string targetScene, TransitionSettings customSettings = null)
     {
-        if(sceneName != "")
+        TransitionSettings settings = customSettings ?? defaultSettings;
+        StartCoroutine(TransitionSequence(targetScene, settings));
+    }
+
+    private IEnumerator TransitionSequence(string targetScene, TransitionSettings settings)
+    {
+        var manager = PixelaterAndGreyScaleManager.Instance;
+        manager.IsTransitioning = true;
+
+        // A -> 로딩
+        if (settings.useOutEffect)
         {
-            targetSceneName = sceneName;
+            // 점진적으로 픽셀화
+            yield return StartCoroutine(FadeEffect(1, 200, 0f, 1f, settings.outDuration, manager));
         }
-        StartCoroutine(TransitionSequence());
+
+        yield return SceneManager.LoadSceneAsync(loadingSceneName);
+        
+        // 잠시 대기
+        yield return new WaitForSeconds(0.5f);
+
+        // 로딩 -> B
+        AsyncOperation op = SceneManager.LoadSceneAsync(targetScene);
+        op.allowSceneActivation = false;
+
+        while (op.progress < 0.9f) yield return null;
+
+        // 씬 전환 전 픽셀 셋팅 (이미 픽셀화된 상태에서 시작)
+        manager.targetPixelSize = 200;
+        manager.targetGreyscale = 1f;
+
+        op.allowSceneActivation = true;
+        while (!op.isDone) yield return null;
+
+        if (settings.useInEffect)
+        {
+            // 점진적으로 해제
+            yield return StartCoroutine(FadeEffect(200, 1, 1f, 0f, settings.inDuration, manager));
+        }
+        else
+        {
+            // 효과 안 쓰면 즉시 해제
+            manager.targetPixelSize = 1;
+            manager.targetGreyscale = 0f;
+        }
+
+        manager.IsTransitioning = false;
     }
 
-    private IEnumerator TransitionSequence()
-{
-    var manager = PixelaterAndGreyScaleManager.Instance;
-    if (manager == null)
-    {
-        Debug.LogError("Pixel Manager를 찾을 수 없습니다!");
-        yield break;
-    }
-
-    manager.IsTransitioning = true;
-
-    yield return SceneManager.LoadSceneAsync(loadingSceneName);
-
-    if (string.IsNullOrEmpty(targetSceneName))
-    {
-        Debug.LogError("타겟 씬 이름이 비어있습니다!");
-        yield break;
-    }
-
-    AsyncOperation op = SceneManager.LoadSceneAsync(targetSceneName);
-    op.allowSceneActivation = false;
-
-    while (op.progress < 0.9f)
-    {
-        yield return null;
-    }
-
-    manager.targetPixelSize = 200;
-    manager.targetGreyscale = 1f;
-
-    op.allowSceneActivation = true;
-    while (!op.isDone) yield return null;
-
-    yield return StartCoroutine(FadeEffect(200, 1, 1f, 0f, manager));
-    
-    manager.IsTransitioning = false;
-}
-
-    private IEnumerator FadeEffect(int startPix, int endPix, float startGrey, float endGrey, PixelaterAndGreyScaleManager manager)
+    private IEnumerator FadeEffect(int startPix, int endPix, float startGrey, float endGrey, float duration, PixelaterAndGreyScaleManager manager)
     {
         float elapsed = 0f;
-        while (elapsed < transitionTime)
+        while (elapsed < duration)
         {
             elapsed += Time.deltaTime;
-            float t = elapsed / transitionTime;
+            float t = elapsed / duration;
 
             manager.targetPixelSize = (int)Mathf.Lerp(startPix, endPix, t);
             manager.targetGreyscale = Mathf.Lerp(startGrey, endGrey, t);

--- a/After Christmas/Assets/03. Prefebs/GHB/ManagerPrefab/StageManager.prefab
+++ b/After Christmas/Assets/03. Prefebs/GHB/ManagerPrefab/StageManager.prefab
@@ -47,6 +47,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   requiredInteractionCount: 1
+  nextSceneName: PixelateManagerTestScene
+  clearTransitionSettings:
+    useOutEffect: 1
+    useInEffect: 0
+    outDuration: 1
+    inDuration: 1
 --- !u!114 &8872491700611202905
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/After Christmas/Assets/03. Prefebs/GHB/PlayerPrefab/Player.prefab
+++ b/After Christmas/Assets/03. Prefebs/GHB/PlayerPrefab/Player.prefab
@@ -1726,6 +1726,7 @@ GameObject:
   - component: {fileID: 3274375634087622306}
   - component: {fileID: 6454227992930729299}
   - component: {fileID: 5225355218624632566}
+  - component: {fileID: 7359695644161184612}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -1921,6 +1922,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetCamera: {fileID: 0}
   smoothSpeed: 5
+--- !u!114 &7359695644161184612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3818844191061978318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeDuration: 1.5
 --- !u!1 &3885781187543271411
 GameObject:
   m_ObjectHideFlags: 0
@@ -2604,7 +2618,7 @@ SkinnedMeshRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: 05791b371dd88704dba53012b9ab30fd, type: 2}
-  - {fileID: 7933312807922358329, guid: d62e78358eda17a479d1be8d03c3bb67, type: 3}
+  - {fileID: 2100000, guid: 05791b371dd88704dba53012b9ab30fd, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/After Christmas/Assets/03. Prefebs/GHB/PlayerPrefab/PlayerFollower.prefab
+++ b/After Christmas/Assets/03. Prefebs/GHB/PlayerPrefab/PlayerFollower.prefab
@@ -4064,6 +4064,7 @@ GameObject:
   - component: {fileID: 6843346924914069819}
   - component: {fileID: 986942205173830225}
   - component: {fileID: 8989523403343134530}
+  - component: {fileID: 3755295408236544129}
   m_Layer: 0
   m_Name: PlayerFollower
   m_TagString: Untagged
@@ -4154,6 +4155,19 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 80
   m_CollisionDetection: 0
+--- !u!114 &3755295408236544129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8022095829948060203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c1953309df466554d83d862c7305562e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeDuration: 1.5
 --- !u!1 &8075853364871258334
 GameObject:
   m_ObjectHideFlags: 0

--- a/After Christmas/Assets/08. Data/Cinematic/Test/CubeTimeline.playable
+++ b/After Christmas/Assets/08. Data/Cinematic/Test/CubeTimeline.playable
@@ -1,0 +1,239 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3930594027859149275
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 1.09, z: 4.05}
+  m_InfiniteClipOffsetEulerAngles: {x: -0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: -282208400797985866}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!74 &-282208400797985866
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.23, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 1.9833333
+        value: {x: 4.8, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.9833333
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.23
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.9833333
+        value: 4.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.9833333
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.9833333
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 1
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: CubeTimeline
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: -3930594027859149275}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+    m_ScenePreview: 1
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}

--- a/After Christmas/Assets/08. Data/Cinematic/Test/CubeTimeline.playable.meta
+++ b/After Christmas/Assets/08. Data/Cinematic/Test/CubeTimeline.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24c0fb7f67c6a544fb80fbf66e5c15de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 🔎 작업 내용


<hr>

* 플레이어 오브젝트를 시네마틱 재생 여부에 맞춰 투명도가 조절되도록 구현했습니다.
  * 투명화는 바로 진행되어야 하기에 duration을 넣지 않았고, 추후 연출적인 부분을 고려해 다시 불투명화가 되는 부분은 duration을 인스펙터에서 설정할 수 있도록 구현해 두었습니다.
  * 기본값 duration은 1.5입니다.
  * DemoTest-UIMakeScene에 간단한 시네마틱을 넣어 뒀으니 해당 씬에서 테스트해보시면 됩니다.

https://github.com/user-attachments/assets/d4d7a1bf-5297-44a6-8b72-af6c9d2181b0


<br> 

* 대화 UI가 켜져있는 동안은 인벤토리 UI가 켜지지 않도록 구현했습니다.


<br> 

* **현재 플레이어가 서 있는 맵이 아닌 맵**에 대해서 Play 모드일 때 setactive(false)가 되도록 구현해 두었습니다.
  * 초기 정보 초기화를 위해서 런타임 시작 시점에는 모든 맵이 active 상태여야 합니다. start map이 아닌 맵들은 자동으로 deactive됩니다.



https://github.com/user-attachments/assets/0b96938a-f96e-4967-bea6-2c7701fc565c


<br> 


* 씬 이동 시 픽셀레이트 효과를 자유롭게 커스텀해 쓸 수 있도록 조건 클래스와 로딩 매니저를 리팩토링했습니다. 사용법은 추후 노션에 정리해 두겠습니다.

<img width="334" height="328" alt="image" src="https://github.com/user-attachments/assets/5c4052f6-4ba4-4cac-8de6-47bb2c1b35bc" />



## 🔧 앞으로의 과제
